### PR TITLE
B-Spline Refactoring

### DIFF
--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -22,14 +22,25 @@ def basis_0(t, knots):
     return jnp.where(condition, 1.0, 0.0)
 
 
-@jit
-def basis(t, knots, k):
+# @jit
+@partial(jit, static_argnames=["k"])
+def basis_i(t, knots, i, *, k):
+    jax.debug.breakpoint()
     jax.lax.cond(
-        k == 0,
+        k == 0, 
         lambda: basis_0(t, knots),
-        lambda: (knots - t) / (basis(t, knots, k-1),
-        operand_stack=[]
+        lambda: (t - knots[i]) / (knots[i+k] - knots[i]) * basis_i(t, knots, i, k=k-1) + (knots[i+k+1] - t) / (knots[i+k+1] - knots[i+1]) * basis_i(t, knots, i+1, k=k-1)
+        # return t0 * basis_i(t, knots, i, k-1) + t1 * basis_i(t, knots, i+1, k-1)
     )
+
+# @jit
+# def basis(t, knots, k):
+#     jax.lax.cond(
+#         k == 0,
+#         lambda: basis_0(t, knots),
+#         lambda: (knots - t) / (basis(t, knots, k-1),
+#         operand_stack=[]
+#     )
 
 
 if __name__ == "__main__":
@@ -44,7 +55,9 @@ if __name__ == "__main__":
 
     print(f"condition: {(knots[:-1] <= t) & (t < knots[1:])}")
 
-    print(f"basis: {basis_0(t, knots)}")
+    print(f"basis_0: {basis_0(t, knots)}")
+
+    print(f"basis_1: {basis_i(t, knots, 0, k=0)}")
 
 
     # Plot the basis functions

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -25,13 +25,18 @@ def basis_0(t, knots):
 # @jit
 @partial(jit, static_argnames=["k"])
 def basis_i(t, knots, i, *, k):
-    jax.debug.breakpoint()
-    jax.lax.cond(
-        k == 0, 
-        lambda: basis_0(t, knots),
-        lambda: (t - knots[i]) / (knots[i+k] - knots[i]) * basis_i(t, knots, i, k=k-1) + (knots[i+k+1] - t) / (knots[i+k+1] - knots[i+1]) * basis_i(t, knots, i+1, k=k-1)
-        # return t0 * basis_i(t, knots, i, k-1) + t1 * basis_i(t, knots, i+1, k-1)
-    )
+    if k == 0:
+        return basis_0(t, knots)
+    else:
+        t0 = (t - knots[i]) / (knots[i+k] - knots[i])
+        t1 = (knots[i+k+1] - t) / (knots[i+k+1] - knots[i+1])
+        return t0 * basis_i(t, knots, i, k=k-1) + t1 * basis_i(t, knots, i+1, k=k-1)
+    # jax.lax.cond(
+    #     k == 0, 
+    #     lambda: basis_0(t, knots),
+    #     lambda: (t - knots[i]) / (knots[i+k] - knots[i]) * basis_i(t, knots, i, k=k-1) + (knots[i+k+1] - t) / (knots[i+k+1] - knots[i+1]) * basis_i(t, knots, i+1, k=k-1)
+    #     # return t0 * basis_i(t, knots, i, k-1) + t1 * basis_i(t, knots, i+1, k-1)
+    # )
 
 # @jit
 # def basis(t, knots, k):
@@ -57,7 +62,8 @@ if __name__ == "__main__":
 
     print(f"basis_0: {basis_0(t, knots)}")
 
-    print(f"basis_1: {basis_i(t, knots, 0, k=0)}")
+    k = 2
+    print(f"basis_{k}: {basis_i(t, knots, 0, k=k)}")
 
 
     # Plot the basis functions

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -15,6 +15,54 @@ from timeit import timeit
 # @jit
 @partial(jit, static_argnums=(3,))
 def basis(t, knots, i, k):
+    """
+    This function evaluates a single B-spline basis function N_{i,k} at t.
+
+    To evaluate an array of basis functions and / or a batch of times,
+    use jax.vmap to vectorize this function.
+
+    For example, to map over all basis functions and evaluate them at a single time t:
+
+        ```
+        n = 40
+        k = 5
+        t = 1.5
+
+        # Define the knot vector
+        knots = jnp.arange(n+k+1)
+
+        indices = jnp.arange(n)
+        basis_funcs = jax.vmap(lambda i: basis(t, knots, i, k), in_axes=0)(indices)
+        ```
+
+    To map over all basis functions _and_ evaluate them at an array of times t (i.e. a batch):
+
+        ```
+        # (...add the code above...)
+
+        t = jnp.linspace(knots[0], knots[-1], 1000).reshape(-1, 1)
+        basis_funcs = jax.vmap(jax.vmap(lambda i: basis(t, knots, i, k), in_axes=0), in_axes=0)(indices)
+        ```
+        
+    Args:
+    -----
+    t: float
+        The time at which to evaluate the basis function
+    knots: jnp.ndarray
+        The knot vector
+    i: int
+        The index of the basis function
+    k: int
+        The degree of the basis function
+
+    Returns:
+    --------
+
+    The value of the basis function at t.
+
+
+
+    """
     if k == 0:
         condition = (knots[i] <= t) & (t < knots[i+1])
         return jnp.where(condition, 1.0, 0.0)

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -2,6 +2,7 @@
 Refactored code to be easier to understand.
 """
 
+import jax
 from jax import jit, random, vmap
 import jax.numpy as jnp
 from functools import partial
@@ -10,17 +11,25 @@ from jax import vmap, lax, debug
 from jax import custom_jvp
 
 
-@partial(jit, static_argnames=["n"])
-def basis_0(t, knots, *, n):
+# @partial(jit, static_argnames=["n"])
+@jit
+def basis_0(t, knots):
     """
     Given a knot vector and the number of control points n, this 
     computes all values of N_{i,0}(t) for i = 0, 1, ..., n-1.
     """
     condition = (knots[:-1] <= t) & (t < knots[1:])
     return jnp.where(condition, 1.0, 0.0)
-    # return 1
 
 
+@jit
+def basis(t, knots, k):
+    jax.lax.cond(
+        k == 0,
+        lambda: basis_0(t, knots),
+        lambda: (knots - t) / (basis(t, knots, k-1),
+        operand_stack=[]
+    )
 
 
 if __name__ == "__main__":
@@ -35,7 +44,7 @@ if __name__ == "__main__":
 
     print(f"condition: {(knots[:-1] <= t) & (t < knots[1:])}")
 
-    print(f"basis: {basis_0(t, knots, n=3)}")
+    print(f"basis: {basis_0(t, knots)}")
 
 
     # Plot the basis functions

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -110,3 +110,7 @@ if __name__ == "__main__":
     
     for i in range(10):
         print(f"Time at {i}: {timeit(lambda: get_bases(t, knots, indices, k).block_until_ready(), number=1)}")
+
+    # Test gradient
+    grad = jax.grad(lambda t: jnp.sum(vmap(basis, in_axes=(0,None,None,None))(t, knots, indices, k)))
+    print(grad(jnp.array([[0.5]])))

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -14,7 +14,7 @@ from timeit import timeit
 
 # @jit
 @partial(jit, static_argnums=(3,))
-def basis_i(t, knots, i, k):
+def basis(t, knots, i, k):
     if k == 0:
         condition = (knots[i] <= t) & (t < knots[i+1])
         return jnp.where(condition, 1.0, 0.0)
@@ -25,18 +25,10 @@ def basis_i(t, knots, i, k):
         t0 = jnp.where(denominator_0 != 0.0, (t - knots[i]) / (knots[i+k] - knots[i]), 0.0)
         t1 = jnp.where(denominator_1 != 0.0, (knots[i+k+1] - t) / (knots[i+k+1] - knots[i+1]), 0.0)
 
-        return t0 * basis_i(t, knots, i, k-1) + t1 * basis_i(t, knots, i+1, k-1)
+        return t0 * basis(t, knots, i, k-1) + t1 * basis(t, knots, i+1, k-1)
 
-basis_vmap = vmap(basis_i, in_axes=(None, None, 0, None), out_axes=0)
+basis_vmap = vmap(basis, in_axes=(None, None, 0, None), out_axes=0)
 
-# @jit
-# def basis(t, knots, k):
-#     jax.lax.cond(
-#         k == 0,
-#         lambda: basis_0(t, knots),
-#         lambda: (knots - t) / (basis(t, knots, k-1),
-#         operand_stack=[]
-#     )
 
 
 if __name__ == "__main__":
@@ -47,31 +39,25 @@ if __name__ == "__main__":
     t = 1.5
 
     # Define the knot vector
-    # knots = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0]) # Good for n=3, k=1
-    # knots = jnp.array([0.0, 0.0, 1.0, 2.0, 3.0, 3.0]) # good for n=3, k=2
-    # knots = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]) # good for n=3, k=2
     knots = jnp.arange(n+k+1)
-
-    print(f"condition: {(knots[:-1] <= t) & (t < knots[1:])}")
-
-    print(f"basis_0: {basis_i(t, knots, 0, 0)}")
-
-    print(f"basis_{k}: {basis_i(t, knots, 0, k)}")
 
     indices = jnp.arange(n)
     print(f"basis: {basis_vmap(t, knots, indices, k)}")
 
-    get_bases = vmap(vmap(basis_i, in_axes=(0, None, None, None)), in_axes=(None, None, 0, None))
+
+    # Function that vmaps over both all basis functions and an input array of t values
+    get_bases = vmap(vmap(basis, in_axes=(0, None, None, None)), in_axes=(None, None, 0, None))
 
     # Plot the basis functions
     t = jnp.linspace(knots[0], knots[-1], 1000).reshape(-1, 1)
     # vals = vmap(vmap(basis_i, in_axes=(0, None, None, None)), in_axes=(None, None, 0, None))(t, knots, indices, k)
     vals = get_bases(t, knots, indices, k)
     for i in range(len(vals)):
-        plt.plot(t, vals[i], label=f"$N_{{i,k}}(t)$")
+        plt.plot(t, vals[i], label=f"$N_{{{i},{k}}}(t)$")
     plt.legend()
     plt.show()
 
+    # Benchmark the runtime _after_ it is JIT compiled.
     print(f"Time: {timeit(lambda: get_bases(t, knots, indices, k).block_until_ready(), number=1)}")
     
     for i in range(10):

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -138,12 +138,15 @@ if __name__ == "__main__":
     plt.legend()
     plt.show()
 
+
+
     # Test clamped spline
     knots_clamped = jnp.concatenate([jnp.zeros(k+1), jnp.arange(1, n-k), jnp.ones(k+1) * (n-k)])
 
     t_clamped = jnp.linspace(knots_clamped[k], knots_clamped[n], n_t)
+    t_clamped = t_clamped.at[-1].set(t_clamped[-1] - 1e-4)
+
     clamped_vals = b(t_clamped, knots_clamped)
-    breakpoint()
 
     plt.plot(clamped_vals[0], clamped_vals[1], label="Clamped Spline")
     plt.plot(ctrl_pts[0], ctrl_pts[1], 'ro--', label="Control Points")

--- a/splinx/spline_v2.py
+++ b/splinx/spline_v2.py
@@ -1,0 +1,49 @@
+"""
+Refactored code to be easier to understand.
+"""
+
+from jax import jit, random, vmap
+import jax.numpy as jnp
+from functools import partial
+import matplotlib.pyplot as plt
+from jax import vmap, lax, debug
+from jax import custom_jvp
+
+
+@partial(jit, static_argnames=["n"])
+def basis_0(t, knots, *, n):
+    """
+    Given a knot vector and the number of control points n, this 
+    computes all values of N_{i,0}(t) for i = 0, 1, ..., n-1.
+    """
+    condition = (knots[:-1] <= t) & (t < knots[1:])
+    return jnp.where(condition, 1.0, 0.0)
+    # return 1
+
+
+
+
+if __name__ == "__main__":
+
+    n = 3
+    k = 1
+
+    t = 1.0
+
+    # Define the knot vector
+    knots = jnp.array([0.0, 1.0, 2.0, 3.0, 4.0])
+
+    print(f"condition: {(knots[:-1] <= t) & (t < knots[1:])}")
+
+    print(f"basis: {basis_0(t, knots, n=3)}")
+
+
+    # Plot the basis functions
+    # t = jnp.linspace(0.0, 3.0, 1000)
+    # y = jnp.array([basis_0(t, knots, i) for i in range(5)])
+    # for i in range(5):
+    #     plt.plot(t, y[i], label=f"$N_{{i,0}}(t)$")
+    # plt.legend()
+    # plt.show()
+
+    


### PR DESCRIPTION
This is a draft PR to simplify the B-Spline code.

This introduces a new file `spline_v2.py` with a single function: `basis()`. This can be used in combination with `vmap` to evaluate B-splines.

The notation more closely matches standard notation.

Still need to add some features such as derivatives, integrals, etc.

For a demo, run `splines_v2.py`.